### PR TITLE
Benchmark feature fixes tests

### DIFF
--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -464,7 +464,10 @@ class JumpStartModel(Model):
         Returns:
             Benchmark Metrics: Pandas DataFrame object.
         """
-        return pd.DataFrame(self._get_deployment_configs_benchmarks_data())
+        df = pd.DataFrame(self._get_deployment_configs_benchmarks_data())
+        default_mask = df.apply(lambda raw: any('Default' in str(val) for val in raw), axis=1)
+        sorted_df = pd.concat([df[default_mask], df[~default_mask]])
+        return sorted_df
 
     def display_benchmark_metrics(self, *args, **kwargs) -> None:
         """Display deployment configs benchmark metrics."""

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -906,6 +906,11 @@ class JumpStartModel(Model):
         err = None
         for config_name, metadata_config in self._metadata_configs.items():
             resolved_config = metadata_config.resolved_config
+
+            print("*************************")
+            print(resolved_config)
+            print("*************************\n")
+
             if selected_config_name == config_name:
                 instance_type_to_use = selected_instance_type
             else:

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -14,7 +14,6 @@
 
 from __future__ import absolute_import
 
-from functools import lru_cache
 from typing import Dict, List, Optional, Any, Union
 import pandas as pd
 from botocore.exceptions import ClientError
@@ -49,6 +48,7 @@ from sagemaker.jumpstart.utils import (
     get_metrics_from_deployment_configs,
     add_instance_rate_stats_to_benchmark_metrics,
     deployment_config_response_data,
+    _deployment_config_lru_cache,
 )
 from sagemaker.jumpstart.constants import JUMPSTART_LOGGER
 from sagemaker.jumpstart.enums import JumpStartModelType
@@ -874,7 +874,7 @@ class JumpStartModel(Model):
 
         return model_package
 
-    @lru_cache
+    @_deployment_config_lru_cache
     def _get_deployment_configs_benchmarks_data(
         self, config_name: str, instance_type: str
     ) -> Dict[str, Any]:
@@ -892,7 +892,7 @@ class JumpStartModel(Model):
             self._get_deployment_configs(config_name, instance_type),
         )
 
-    @lru_cache
+    @_deployment_config_lru_cache
     def _get_deployment_configs(
         self, selected_config_name: str, selected_instance_type: str
     ) -> List[DeploymentConfigMetadata]:

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -906,11 +906,6 @@ class JumpStartModel(Model):
         err = None
         for config_name, metadata_config in self._metadata_configs.items():
             resolved_config = metadata_config.resolved_config
-
-            print("*************************")
-            print(resolved_config)
-            print("*************************\n")
-
             if selected_config_name == config_name:
                 instance_type_to_use = selected_instance_type
             else:

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -464,7 +464,7 @@ class JumpStartModel(Model):
         Returns:
             Benchmark Metrics: Pandas DataFrame object.
         """
-        return pd.DataFrame(self._get_deployment_configs_benchmarks_data()).df.apply(lambda raw: any('Default' in str(val) for val in raw), axis=1)
+        return pd.DataFrame(self._get_deployment_configs_benchmarks_data()).apply(lambda raw: any('Default' in str(val) for val in raw), axis=1)
 
     def display_benchmark_metrics(self, *args, **kwargs) -> None:
         """Display deployment configs benchmark metrics."""

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -464,7 +464,7 @@ class JumpStartModel(Model):
         Returns:
             Benchmark Metrics: Pandas DataFrame object.
         """
-        return pd.DataFrame(self._get_deployment_configs_benchmarks_data())
+        return pd.DataFrame(self._get_deployment_configs_benchmarks_data()).df.apply(lambda raw: any('Default' in str(val) for val in raw), axis=1)
 
     def display_benchmark_metrics(self, *args, **kwargs) -> None:
         """Display deployment configs benchmark metrics."""

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -465,7 +465,7 @@ class JumpStartModel(Model):
             Benchmark Metrics: Pandas DataFrame object.
         """
         df = pd.DataFrame(self._get_deployment_configs_benchmarks_data())
-        default_mask = df.apply(lambda raw: any('Default' in str(val) for val in raw), axis=1)
+        default_mask = df.apply(lambda row: any("Default" in str(val) for val in row), axis=1)
         sorted_df = pd.concat([df[default_mask], df[~default_mask]])
         return sorted_df
 

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -464,7 +464,7 @@ class JumpStartModel(Model):
         Returns:
             Benchmark Metrics: Pandas DataFrame object.
         """
-        return pd.DataFrame(self._get_deployment_configs_benchmarks_data()).apply(lambda raw: any('Default' in str(val) for val in raw), axis=1)
+        return pd.DataFrame(self._get_deployment_configs_benchmarks_data())
 
     def display_benchmark_metrics(self, *args, **kwargs) -> None:
         """Display deployment configs benchmark metrics."""

--- a/src/sagemaker/jumpstart/model.py
+++ b/src/sagemaker/jumpstart/model.py
@@ -472,9 +472,9 @@ class JumpStartModel(Model):
         df = pd.DataFrame(benchmark_metrics_data).sort_values(by=[keys[1], keys[0]])
         return df
 
-    def display_benchmark_metrics(self) -> None:
+    def display_benchmark_metrics(self, *args, **kwargs) -> None:
         """Display deployment configs benchmark metrics."""
-        print(self.benchmark_metrics.to_markdown(index=False))
+        print(self.benchmark_metrics.to_markdown(index=False), *args, **kwargs)
 
     def list_deployment_configs(self) -> List[Dict[str, Any]]:
         """List deployment configs for ``This`` model.
@@ -903,7 +903,7 @@ class JumpStartModel(Model):
             selected_instance_type (str): The selected instance type.
         """
         deployment_configs = []
-        if self._metadata_configs is None:
+        if not self._metadata_configs:
             return deployment_configs
 
         err = None
@@ -940,7 +940,7 @@ class JumpStartModel(Model):
             )
             deployment_configs.append(deployment_config_metadata)
 
-        if err is not None and "is not authorized to perform: pricing:GetProducts" in err:
+        if err and "is not authorized to perform: pricing:GetProducts" in err:
             error_message = "Instance rate metrics will be omitted. Reason: %s"
             JUMPSTART_LOGGER.warning(error_message, err)
 

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1213,9 +1213,9 @@ def _deployment_config_lru_cache(_func=None, *, maxsize: int = 128, typed: bool 
                     keys = list(res.keys())
                     if "Instance Rate" not in keys[-1]:
                         f.cache_clear()
-                    elif len(res[keys[1]]) > len(res[keys[-1]]):
-                        del res[keys[-1]]
-                        f.cache_clear()
+                    # elif len(res[keys[1]]) > len(res[keys[-1]]):
+                    #     del res[keys[-1]]
+                    #     f.cache_clear()
             else:
                 print("******* From Cache ***********")
                 print(res)

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1196,7 +1196,7 @@ def _deployment_config_lru_cache(_func=None, *, maxsize: int = 128, typed: bool 
         def wrapped_f(*args, **kwargs):
             res = f(*args, **kwargs)
 
-            if f.cache_info().hits == 1:
+            if f.cache_info().hits == 0 and f.cache_info().misses == 1:
                 print("******* Not From Cache ***********")
                 print(res)
                 print()

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1211,7 +1211,10 @@ def _deployment_config_lru_cache(_func=None, *, maxsize: int = 128, typed: bool 
                             break
                 elif isinstance(res, dict):
                     keys = list(res.keys())
-                    if len(keys) > 3 and "Instance Rate" not in keys[2]:
+                    if "Instance Rate" not in keys[-1]:
+                        f.cache_clear()
+                    elif len(res[keys[1]]) > len(res[keys[-1]]):
+                        del res[keys[-1]]
                         f.cache_clear()
             else:
                 print("******* From Cache ***********")

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1118,13 +1118,6 @@ def get_metrics_from_deployment_configs(
         if not deployment_config.deployment_args or not benchmark_metrics:
             continue
 
-        default_instance_type = deployment_config.deployment_args.default_instance_type
-        if default_instance_type in benchmark_metrics:
-            benchmark_metrics = {
-                default_instance_type: benchmark_metrics.pop(default_instance_type),
-                **benchmark_metrics,
-            }
-
         for inner_index, current_instance_type in enumerate(benchmark_metrics):
             current_instance_type_metrics = benchmark_metrics[current_instance_type]
 

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1024,7 +1024,9 @@ def get_jumpstart_configs(
         raise ValueError(f"Unknown script scope: {scope}.")
 
     if not config_names:
-        config_names = metadata_configs.config_rankings.get("overall").rankings if metadata_configs else []
+        config_names = (
+            metadata_configs.config_rankings.get("overall").rankings if metadata_configs else []
+        )
 
     return (
         {config_name: metadata_configs.configs[config_name] for config_name in config_names}
@@ -1094,15 +1096,11 @@ def has_instance_rate_stat(benchmark_metric_stats: Optional[List[JumpStartBenchm
 
 
 def get_metrics_from_deployment_configs(
-    default_config_name: Optional[str],
-    default_instance_type: Optional[str],
     deployment_configs: Optional[List[DeploymentConfigMetadata]],
 ) -> Dict[str, List[str]]:
     """Extracts benchmark metrics from deployment configs metadata.
 
     Args:
-        default_config_name (Optional[str]): The name of the default deployment config.
-        default_instance_type (Optional[str]): The name of the default instance type.
         deployment_configs (Optional[List[DeploymentConfigMetadata]]):
         List of deployment configs metadata.
     Returns:
@@ -1124,7 +1122,8 @@ def get_metrics_from_deployment_configs(
             data["Config Name"].append(deployment_config.deployment_config_name)
             instance_type_to_display = (
                 f"{current_instance_type} (Default)"
-                if index == 0 and current_instance_type == deployment_config.deployment_args.default_instance_type
+                if index == 0
+                and current_instance_type == deployment_config.deployment_args.default_instance_type
                 else current_instance_type
             )
             data["Instance Type"].append(instance_type_to_display)

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1123,7 +1123,7 @@ def get_metrics_from_deployment_configs(
             instance_type_to_display = (
                 f"{current_instance_type} (Default)"
                 if index == 0
-                and current_instance_type == deployment_config.deployment_args.default_instance_type
+                # and current_instance_type == deployment_config.deployment_args.default_instance_type
                 else current_instance_type
             )
             data["Instance Type"].append(instance_type_to_display)

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1197,11 +1197,6 @@ def _deployment_config_lru_cache(_func=None, *, maxsize: int = 128, typed: bool 
             res = f(*args, **kwargs)
 
             if f.cache_info().hits == 0 and f.cache_info().misses == 1:
-                print("******* Not From Cache ***********")
-                print(res)
-                print()
-                print(f.cache_info())
-                print()
                 if isinstance(res, list):
                     for item in res:
                         if isinstance(
@@ -1213,14 +1208,9 @@ def _deployment_config_lru_cache(_func=None, *, maxsize: int = 128, typed: bool 
                     keys = list(res.keys())
                     if "Instance Rate" not in keys[-1]:
                         f.cache_clear()
-                    # elif len(res[keys[1]]) > len(res[keys[-1]]):
-                    #     del res[keys[-1]]
-                    #     f.cache_clear()
-            else:
-                print("******* From Cache ***********")
-                print(res)
-                print()
-                print(f.cache_info())
+                    elif len(res[keys[1]]) > len(res[keys[-1]]):
+                        del res[keys[-1]]
+                        f.cache_clear()
 
             return res
 

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1024,7 +1024,7 @@ def get_jumpstart_configs(
         raise ValueError(f"Unknown script scope: {scope}.")
 
     if not config_names:
-        config_names = metadata_configs.configs.keys() if metadata_configs else []
+        config_names = metadata_configs.config_rankings.get("rankings", []) if metadata_configs else []
 
     return (
         {config_name: metadata_configs.configs[config_name] for config_name in config_names}
@@ -1113,7 +1113,7 @@ def get_metrics_from_deployment_configs(
 
     data = {"Instance Type": [], "Config Name": []}
     instance_rate_data = {}
-    for deployment_config in deployment_configs:
+    for index, deployment_config in enumerate(deployment_configs):
         benchmark_metrics = deployment_config.benchmark_metrics
         if not deployment_config.deployment_args or not benchmark_metrics:
             continue
@@ -1124,8 +1124,7 @@ def get_metrics_from_deployment_configs(
             data["Config Name"].append(deployment_config.deployment_config_name)
             instance_type_to_display = (
                 f"{current_instance_type} (Default)"
-                if current_instance_type == default_instance_type
-                and deployment_config.deployment_config_name == default_config_name
+                if index == 0
                 else current_instance_type
             )
             data["Instance Type"].append(instance_type_to_display)

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1036,15 +1036,15 @@ def get_jumpstart_configs(
 def add_instance_rate_stats_to_benchmark_metrics(
     region: str,
     benchmark_metrics: Optional[Dict[str, List[JumpStartBenchmarkStat]]],
-) -> Optional[Tuple[str, Dict[str, List[JumpStartBenchmarkStat]]]]:
+) -> Optional[Tuple[Dict[str, str], Dict[str, List[JumpStartBenchmarkStat]]]]:
     """Adds instance types metric stats to the given benchmark_metrics dict.
 
     Args:
         region (str): AWS region.
         benchmark_metrics (Optional[Dict[str, List[JumpStartBenchmarkStat]]]):
     Returns:
-        Optional[Tuple[str, Dict[str, List[JumpStartBenchmarkStat]]]]:
-        Contains Error message and metrics dict.
+        Optional[Tuple[Dict[str, str], Dict[str, List[JumpStartBenchmarkStat]]]]:
+        Contains Error and metrics.
     """
     if not benchmark_metrics:
         return None
@@ -1067,7 +1067,7 @@ def add_instance_rate_stats_to_benchmark_metrics(
                 final_benchmark_metrics[instance_type] = benchmark_metric_stats
             except ClientError as e:
                 final_benchmark_metrics[instance_type] = benchmark_metric_stats
-                err_message = e.response["Error"]["Message"]
+                err_message = e.response["Error"]
             except Exception:  # pylint: disable=W0703
                 final_benchmark_metrics[instance_type] = benchmark_metric_stats
         else:

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1023,10 +1023,6 @@ def get_jumpstart_configs(
     else:
         raise ValueError(f"Unknown script scope: {scope}.")
 
-    # print("******************************")
-    # print(metadata_configs.config_rankings.get("overall").rankings)
-    # print("******************************")
-
     if not config_names:
         config_names = metadata_configs.config_rankings.get("overall").rankings if metadata_configs else []
 
@@ -1128,7 +1124,7 @@ def get_metrics_from_deployment_configs(
             data["Config Name"].append(deployment_config.deployment_config_name)
             instance_type_to_display = (
                 f"{current_instance_type} (Default)"
-                if index == 0
+                if index == 0 and current_instance_type == deployment_config.deployment_args.default_instance_type
                 else current_instance_type
             )
             data["Instance Type"].append(instance_type_to_display)

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1200,7 +1200,7 @@ def _deployment_config_lru_cache(_func=None, *, maxsize: int = 128, typed: bool 
                 print("******* Not From Cache ***********")
                 print(res)
                 print()
-                print(f.cache_info().misses)
+                print(f.cache_info())
                 print()
                 if isinstance(res, list):
                     for item in res:

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1131,7 +1131,7 @@ def get_metrics_from_deployment_configs(
             instance_type_to_display = (
                 f"{current_instance_type} (Default)"
                 if index == 0
-                # and current_instance_type == deployment_config.deployment_args.default_instance_type
+                and current_instance_type == deployment_config.deployment_args.default_instance_type
                 else current_instance_type
             )
             data["Instance Type"].append(instance_type_to_display)

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1028,7 +1028,7 @@ def get_jumpstart_configs(
     print("******************************")
 
     if not config_names:
-        config_names = metadata_configs.config_rankings.get("rankings", []) if metadata_configs else []
+        config_names = metadata_configs.configs.keys() if metadata_configs else []
 
     return (
         {config_name: metadata_configs.configs[config_name] for config_name in config_names}

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 """This module contains utilities related to SageMaker JumpStart."""
 from __future__ import absolute_import
+
+import copy
 import logging
 import os
 from functools import lru_cache, wraps
@@ -1116,16 +1118,19 @@ def get_metrics_from_deployment_configs(
         if not deployment_config.deployment_args or not benchmark_metrics:
             continue
 
-        ranking_benchmark_metrics = {}
+        copy_benchmark_metrics = copy.deepcopy(benchmark_metrics)
+        benchmark_metrics = {}
         if index == 0:
-            ranking_benchmark_metrics[deployment_config.deployment_args.default_instance_type] = benchmark_metrics.get(deployment_config.deployment_args.default_instance_type)
-            del benchmark_metrics[deployment_config.deployment_args.default_instance_type]
-            ranking_benchmark_metrics = {**ranking_benchmark_metrics, **benchmark_metrics}
+            benchmark_metrics[deployment_config.deployment_args.default_instance_type] = (
+                copy_benchmark_metrics.get(deployment_config.deployment_args.default_instance_type)
+            )
+            del copy_benchmark_metrics[deployment_config.deployment_args.default_instance_type]
+            benchmark_metrics = {**benchmark_metrics, **copy_benchmark_metrics}
         else:
-            ranking_benchmark_metrics = benchmark_metrics
+            benchmark_metrics = copy_benchmark_metrics
 
-        for inner_index, current_instance_type in enumerate(ranking_benchmark_metrics):
-            current_instance_type_metrics = ranking_benchmark_metrics[current_instance_type]
+        for inner_index, current_instance_type in enumerate(benchmark_metrics):
+            current_instance_type_metrics = benchmark_metrics[current_instance_type]
 
             data["Config Name"].append(deployment_config.deployment_config_name)
             instance_type_to_display = (

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1119,10 +1119,11 @@ def get_metrics_from_deployment_configs(
             continue
 
         default_instance_type = deployment_config.deployment_args.default_instance_type
-        benchmark_metrics = {
-            default_instance_type: benchmark_metrics.pop(default_instance_type),
-            **benchmark_metrics,
-        }
+        if default_instance_type in benchmark_metrics:
+            benchmark_metrics = {
+                default_instance_type: benchmark_metrics.pop(default_instance_type),
+                **benchmark_metrics,
+            }
 
         for inner_index, current_instance_type in enumerate(benchmark_metrics):
             current_instance_type_metrics = benchmark_metrics[current_instance_type]

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -13,7 +13,6 @@
 """This module contains utilities related to SageMaker JumpStart."""
 from __future__ import absolute_import
 
-import copy
 import logging
 import os
 from functools import lru_cache, wraps

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1023,6 +1023,10 @@ def get_jumpstart_configs(
     else:
         raise ValueError(f"Unknown script scope: {scope}.")
 
+    print("******************************")
+    print(metadata_configs.config_rankings)
+    print("******************************")
+
     if not config_names:
         config_names = metadata_configs.config_rankings.get("rankings", []) if metadata_configs else []
 

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1125,7 +1125,7 @@ def get_metrics_from_deployment_configs(
             ranking_benchmark_metrics = benchmark_metrics
 
         for inner_index, current_instance_type in enumerate(ranking_benchmark_metrics):
-            current_instance_type_metrics = benchmark_metrics[current_instance_type]
+            current_instance_type_metrics = ranking_benchmark_metrics[current_instance_type]
 
             data["Config Name"].append(deployment_config.deployment_config_name)
             instance_type_to_display = (

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1024,7 +1024,7 @@ def get_jumpstart_configs(
         raise ValueError(f"Unknown script scope: {scope}.")
 
     print("******************************")
-    print(metadata_configs.config_rankings)
+    print(metadata_configs.config_rankings.get("overall").rankings)
     print("******************************")
 
     if not config_names:

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1215,6 +1215,9 @@ def _deployment_config_lru_cache(_func=None, *, maxsize: int = 128, typed: bool 
                         f.cache_clear()
             else:
                 print("******* From Cache ***********")
+                print(res)
+                print()
+                print(f.cache_info())
 
             return res
 

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1118,16 +1118,11 @@ def get_metrics_from_deployment_configs(
         if not deployment_config.deployment_args or not benchmark_metrics:
             continue
 
-        copy_benchmark_metrics = copy.deepcopy(benchmark_metrics)
-        benchmark_metrics = {}
-        if index == 0:
-            benchmark_metrics[deployment_config.deployment_args.default_instance_type] = (
-                copy_benchmark_metrics.get(deployment_config.deployment_args.default_instance_type)
-            )
-            del copy_benchmark_metrics[deployment_config.deployment_args.default_instance_type]
-            benchmark_metrics = {**benchmark_metrics, **copy_benchmark_metrics}
-        else:
-            benchmark_metrics = copy_benchmark_metrics
+        default_instance_type = deployment_config.deployment_args.default_instance_type
+        benchmark_metrics = {
+            default_instance_type: benchmark_metrics.pop(default_instance_type),
+            **benchmark_metrics,
+        }
 
         for inner_index, current_instance_type in enumerate(benchmark_metrics):
             current_instance_type_metrics = benchmark_metrics[current_instance_type]

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1023,12 +1023,12 @@ def get_jumpstart_configs(
     else:
         raise ValueError(f"Unknown script scope: {scope}.")
 
-    print("******************************")
-    print(metadata_configs.config_rankings.get("overall").rankings)
-    print("******************************")
+    # print("******************************")
+    # print(metadata_configs.config_rankings.get("overall").rankings)
+    # print("******************************")
 
     if not config_names:
-        config_names = metadata_configs.configs.keys() if metadata_configs else []
+        config_names = metadata_configs.config_rankings.get("overall").rankings if metadata_configs else []
 
     return (
         {config_name: metadata_configs.configs[config_name] for config_name in config_names}

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1198,6 +1198,10 @@ def _deployment_config_lru_cache(_func=None, *, maxsize: int = 128, typed: bool 
 
             if f.cache_info().hits == 1:
                 print("******* Not From Cache ***********")
+                print(res)
+                print()
+                print(f.cache_info().misses)
+                print()
                 if isinstance(res, list):
                     for item in res:
                         if isinstance(

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1086,7 +1086,7 @@ def has_instance_rate_stat(benchmark_metric_stats: Optional[List[JumpStartBenchm
         bool: Whether the benchmark metric stats contains instance rate metric stat.
     """
     if benchmark_metric_stats is None:
-        return False
+        return True
     for benchmark_metric_stat in benchmark_metric_stats:
         if benchmark_metric_stat.name.lower() == "instance rate":
             return True
@@ -1183,7 +1183,7 @@ def _deployment_config_lru_cache(_func=None, *, maxsize: int = 128, typed: bool 
     def has_instance_rate_metric(config: DeploymentConfigMetadata) -> bool:
         """Determines whether a benchmark metric stats contains instance rate metric stat."""
         if config.benchmark_metrics is None:
-            return False
+            return True
         for benchmark_metric_stats in config.benchmark_metrics.values():
             if not has_instance_rate_stat(benchmark_metric_stats):
                 return False

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1116,14 +1116,22 @@ def get_metrics_from_deployment_configs(
         if not deployment_config.deployment_args or not benchmark_metrics:
             continue
 
-        for inner_index, current_instance_type in enumerate(benchmark_metrics):
+        ranking_benchmark_metrics = {}
+        if index == 0:
+            ranking_benchmark_metrics[deployment_config.deployment_args.default_instance_type] = benchmark_metrics.get(deployment_config.deployment_args.default_instance_type)
+            del benchmark_metrics[deployment_config.deployment_args.default_instance_type]
+            ranking_benchmark_metrics = {**ranking_benchmark_metrics, **benchmark_metrics}
+        else:
+            ranking_benchmark_metrics = benchmark_metrics
+
+        for inner_index, current_instance_type in enumerate(ranking_benchmark_metrics):
             current_instance_type_metrics = benchmark_metrics[current_instance_type]
 
             data["Config Name"].append(deployment_config.deployment_config_name)
             instance_type_to_display = (
                 f"{current_instance_type} (Default)"
                 if index == 0
-                and current_instance_type == deployment_config.deployment_args.default_instance_type
+                # and current_instance_type == deployment_config.deployment_args.default_instance_type
                 else current_instance_type
             )
             data["Instance Type"].append(instance_type_to_display)

--- a/src/sagemaker/jumpstart/utils.py
+++ b/src/sagemaker/jumpstart/utils.py
@@ -1123,7 +1123,7 @@ def get_metrics_from_deployment_configs(
             instance_type_to_display = (
                 f"{current_instance_type} (Default)"
                 if index == 0
-                # and current_instance_type == deployment_config.deployment_args.default_instance_type
+                and current_instance_type == deployment_config.deployment_args.default_instance_type
                 else current_instance_type
             )
             data["Instance Type"].append(instance_type_to_display)

--- a/tests/unit/sagemaker/jumpstart/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_utils.py
@@ -1770,7 +1770,7 @@ def test_extract_metrics_from_deployment_configs():
     configs[0].benchmark_metrics = None
     configs[2].deployment_args = None
 
-    data = utils.get_metrics_from_deployment_configs(configs)
+    data = utils.get_metrics_from_deployment_configs("neuron-inference", "ml.g5.xlarge", configs)
 
     for key in data:
         assert len(data[key]) == (len(configs) - 2)

--- a/tests/unit/sagemaker/jumpstart/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_utils.py
@@ -1815,7 +1815,13 @@ def test_add_instance_rate_stats_to_benchmark_metrics_client_ex(
     mock_get_instance_rate_per_hour,
 ):
     mock_get_instance_rate_per_hour.side_effect = ClientError(
-        {"Error": {"Message": "is not authorized to perform: pricing:GetProducts"}}, "GetProducts"
+        {
+            "Error": {
+                "Message": "is not authorized to perform: pricing:GetProducts",
+                "Code": "AccessDenied",
+            },
+        },
+        "GetProducts",
     )
 
     err, out = utils.add_instance_rate_stats_to_benchmark_metrics(
@@ -1827,7 +1833,8 @@ def test_add_instance_rate_stats_to_benchmark_metrics_client_ex(
         },
     )
 
-    assert err == "is not authorized to perform: pricing:GetProducts"
+    assert err["Message"] == "is not authorized to perform: pricing:GetProducts"
+    assert err["Code"] == "AccessDenied"
     for key in out:
         assert len(out[key]) == 1
 

--- a/tests/unit/sagemaker/jumpstart/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_utils.py
@@ -1770,7 +1770,7 @@ def test_extract_metrics_from_deployment_configs():
     configs[0].benchmark_metrics = None
     configs[2].deployment_args = None
 
-    data = utils.get_metrics_from_deployment_configs("neuron-inference", "ml.g5.xlarge", configs)
+    data = utils.get_metrics_from_deployment_configs(configs)
 
     for key in data:
         assert len(data[key]) == (len(configs) - 2)

--- a/tests/unit/sagemaker/jumpstart/test_utils.py
+++ b/tests/unit/sagemaker/jumpstart/test_utils.py
@@ -1835,7 +1835,7 @@ def test_add_instance_rate_stats_to_benchmark_metrics_client_ex(
 @pytest.mark.parametrize(
     "stats, expected",
     [
-        (None, False),
+        (None, True),
         (
             [JumpStartBenchmarkStat({"name": "Instance Rate", "unit": "USD/Hrs", "value": "3.76"})],
             True,

--- a/tests/unit/sagemaker/jumpstart/utils.py
+++ b/tests/unit/sagemaker/jumpstart/utils.py
@@ -358,7 +358,8 @@ def get_base_deployment_configs_metadata(
         else get_base_spec_with_prototype_configs()
     )
     configs = []
-    for config_name, jumpstart_config in specs.inference_configs.configs.items():
+    for config_name in specs.inference_configs.config_rankings.get("overall").rankings:
+        jumpstart_config = specs.inference_configs.configs.get(config_name)
         benchmark_metrics = jumpstart_config.benchmark_metrics
 
         if benchmark_metrics:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Unit tests
* Customize Python LRU to only cache when output is complete

*Testing done:*
Notebook

-- Without identity-based policy that allows the pricing:GetProducts action
```
jumpstart_model = JumpStartModel(model_id="meta-textgeneration-llama-3-70b")
jumpstart_model.list_deployment_configs()

Instance rate metrics will be omitted. Reason: User: arn:aws:sts::312206380606:assumed-role/AmazonSageMaker-ExecutionRole-20230707T131628/SageMaker is not authorized to perform: pricing:GetProducts because no identity-based policy allows the pricing:GetProducts action
[{'DeploymentConfigName': 'tgi',
  'DeploymentArgs': {'ImageUri': '875423407011.dkr.ecr.us-west-2.amazonaws.com/suzuka-beta:djl-serving-v3.2',
   'ModelData': {'S3DataSource': {'S3Uri': 's3://jumpstart-private-cache-prod-us-west-2/meta-textgeneration/meta-textgeneration-llama-3-70b/artifacts/inference-prepack/v1.0.0/',
     'S3DataType': 'S3Prefix',
     'CompressionType': 'None'}},
   'Environment': {'SAGEMAKER_PROGRAM': 'inference.py',
    'ENDPOINT_SERVER_TIMEOUT': '3600',
    'MODEL_CACHE_ROOT': '/opt/ml/model',
    'SAGEMAKER_ENV': '1',
    'HF_MODEL_ID': '/opt/ml/model',
    'SERVING_LOAD_MODELS': 'test::MPI=/opt/ml/model',
    'OPTION_MODEL_ID': '/opt/ml/model',
    'OPTION_SPECULATIVE_DRAFT_MODEL': 'sagemaker',
    'OPTION_TENSOR_PARALLEL_DEGREE': 'max',
    'OPTION_MAX_ROLLING_BATCH_SIZE': '64',
    'OPTION_ROLLING_BATCH': 'lmi-dist',
    'OPTION_GPU_MEMORY_UTILIZATION': '0.85',
    'SAGEMAKER_MODEL_SERVER_WORKERS': '1'},
   'InstanceType': 'ml.p4d.24xlarge',
   'ComputeResourceRequirements': {'MinMemoryRequiredInMb': 589824,
    'NumberOfAcceleratorDevicesRequired': 8},
   'ModelDataDownloadTimeout': 1200,
   'ContainerStartupHealthCheckTimeout': 1200},
  'AccelerationConfigs': None,
  'BenchmarkMetrics': None},
 {'DeploymentConfigName': 'lmi',
  'DeploymentArgs': {'ImageUri': '875423407011.dkr.ecr.us-west-2.amazonaws.com/suzuka-beta:djl-serving-v3.2',
   'ModelData': {'S3DataSource': {'S3Uri': 's3://jumpstart-private-cache-prod-us-west-2/meta-textgeneration/meta-textgeneration-llama-3-70b/artifacts/inference-prepack/v1.0.0/',
     'S3DataType': 'S3Prefix',
     'CompressionType': 'None'}},
   'Environment': {'SAGEMAKER_PROGRAM': 'inference.py',
    'ENDPOINT_SERVER_TIMEOUT': '3600',
    'MODEL_CACHE_ROOT': '/opt/ml/model',
    'SAGEMAKER_ENV': '1',
    'HF_MODEL_ID': '/opt/ml/model',
    'SERVING_LOAD_MODELS': 'test::MPI=/opt/ml/model',
    'OPTION_MODEL_ID': '/opt/ml/model',
    'OPTION_SPECULATIVE_DRAFT_MODEL': 'sagemaker',
    'OPTION_TENSOR_PARALLEL_DEGREE': 'max',
    'OPTION_MAX_ROLLING_BATCH_SIZE': '64',
    'OPTION_ROLLING_BATCH': 'lmi-dist',
    'OPTION_GPU_MEMORY_UTILIZATION': '0.85',
    'SAGEMAKER_MODEL_SERVER_WORKERS': '1'},
   'InstanceType': 'ml.p4d.24xlarge',
   'ComputeResourceRequirements': {'MinMemoryRequiredInMb': 589824,
    'NumberOfAcceleratorDevicesRequired': 8},
   'ModelDataDownloadTimeout': 1200,
   'ContainerStartupHealthCheckTimeout': 1200},
  'AccelerationConfigs': None,
  'BenchmarkMetrics': {'ml.p4d.24xlarge': [{'name': 'Min Latency',
     'value': '26',
     'unit': 'ms/token'},
    {'name': 'Max Throughput', 'value': '983', 'unit': 'tokens/sec'},
    {'name': 'Max Concurrency', 'value': '256', 'unit': 'count'}]}},
 {'DeploymentConfigName': 'lmi-accelerated',
  'DeploymentArgs': {'ImageUri': '875423407011.dkr.ecr.us-west-2.amazonaws.com/suzuka-beta:djl-serving-v3.2',
   'ModelData': {'S3DataSource': {'S3Uri': 's3://jumpstart-private-cache-prod-us-west-2/meta-textgeneration/meta-textgeneration-llama-3-70b/artifacts/inference-prepack/v1.0.0/',
     'S3DataType': 'S3Prefix',
     'CompressionType': 'None'}},
   'Environment': {'SAGEMAKER_PROGRAM': 'inference.py',
    'ENDPOINT_SERVER_TIMEOUT': '3600',
    'MODEL_CACHE_ROOT': '/opt/ml/model',
    'SAGEMAKER_ENV': '1',
    'HF_MODEL_ID': '/opt/ml/model',
    'SERVING_LOAD_MODELS': 'test::MPI=/opt/ml/model',
    'OPTION_MODEL_ID': '/opt/ml/model',
    'OPTION_SPECULATIVE_DRAFT_MODEL': 'sagemaker',
    'OPTION_TENSOR_PARALLEL_DEGREE': 'max',
    'OPTION_MAX_ROLLING_BATCH_SIZE': '64',
    'OPTION_ROLLING_BATCH': 'lmi-dist',
    'OPTION_GPU_MEMORY_UTILIZATION': '0.85',
    'SAGEMAKER_MODEL_SERVER_WORKERS': '1'},
   'InstanceType': 'ml.p4d.24xlarge',
   'ComputeResourceRequirements': {'MinMemoryRequiredInMb': 589824,
    'NumberOfAcceleratorDevicesRequired': 8},
   'ModelDataDownloadTimeout': 1200,
   'ContainerStartupHealthCheckTimeout': 1200},
  'AccelerationConfigs': None,
  'BenchmarkMetrics': {'ml.p4d.24xlarge': [{'name': 'Min Latency',
     'value': '10',
     'unit': 'ms/token'},
    {'name': 'Max Throughput', 'value': '635', 'unit': 'tokens/sec'},
    {'name': 'Max Concurrency', 'value': '64', 'unit': 'count'}]}}]
```

```
jumpstart_model.display_benchmark_metrics()

Instance rate metrics will be omitted. Reason: User: arn:aws:sts::312206380606:assumed-role/AmazonSageMaker-ExecutionRole-20230707T131628/SageMaker is not authorized to perform: pricing:GetProducts because no identity-based policy allows the pricing:GetProducts action
| Instance Type             | Config Name     |   Min Latency (ms/token) |   Max Throughput (tokens/sec) |   Max Concurrency (count) |
|:--------------------------|:----------------|-------------------------:|------------------------------:|--------------------------:|
| ml.g5.48xlarge            | lmi             |                       57 |                            60 |                         8 |
| ml.p4d.24xlarge           | lmi             |                       26 |                           983 |                       256 |
| ml.g5.48xlarge            | lmi-accelerated |                       33 |                            43 |                         8 |
| ml.p4d.24xlarge (Default) | lmi-accelerated |                       10 |                           635 |                        64 |
```

-- With identity-based policy that allows the pricing:GetProducts action: No need to reboot the kernel, the output will be cached so future requests can use.

NOTE: After adding the policy, need to give it at least 10 seconds to propagate. 

```
jumpstart_model.display_benchmark_metrics()

| Instance Type             | Config Name     |   Min Latency (ms/token) |   Max Throughput (tokens/sec) |   Max Concurrency (count) |   Instance Rate (USD/Hrs) |
|:--------------------------|:----------------|-------------------------:|------------------------------:|--------------------------:|--------------------------:|
| ml.g5.48xlarge            | lmi             |                       57 |                            60 |                         8 |                     20.36 |
| ml.p4d.24xlarge           | lmi             |                       26 |                           983 |                       256 |                     38.67 |
| ml.g5.48xlarge            | lmi-accelerated |                       33 |                            43 |                         8 |                     20.36 |
| ml.p4d.24xlarge (Default) | lmi-accelerated |                       10 |                           635 |                        64 |                     38.67 |
```



## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [x ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ x] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [x ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
